### PR TITLE
Fix EOL lexing after beginstream token

### DIFF
--- a/src/Wisp/Parsing/CosLexer.cs
+++ b/src/Wisp/Parsing/CosLexer.cs
@@ -23,41 +23,6 @@ public sealed class CosLexer : IDisposable
         }
     }
 
-    public void ReadEndOfLineMarker()
-    {
-        EnsureNotDisposed();
-
-        // PDF Spec - 7.3.8.1, Paragraph 3.
-        // The keyword stream that follows the stream dictionary shall be followed by an end-of-line marker
-        // consisting of either a CARRIAGE RETURN and a LINE FEED or just a LINE FEED, and not by a CARRIAGE
-        // RETURN alone.
-        // See also NOTE 2 in the same section.
-        while (_reader.CanRead)
-        {
-            var current = _reader.ReadChar();
-            if (current == '\n')
-            {
-                return;
-            }
-            else if (current == '\r')
-            {
-                current = _reader.ReadChar();
-                if (current == '\n')
-                {
-                    return;
-                }
-                else
-                {
-                    throw new WispLexerException(this, $"Invalid end-of-line marker. Expected LF, instead got '{current}'");
-                }
-            }
-            else
-            {
-                throw new WispLexerException(this, "Expected an end-of-line marker consisting either of CRLF or a single LF.");
-            }
-        }
-    }
-
     public long Seek(long offset, SeekOrigin origin)
     {
         return _reader.Seek(offset, origin);

--- a/src/Wisp/Parsing/CosLexer.cs
+++ b/src/Wisp/Parsing/CosLexer.cs
@@ -23,21 +23,37 @@ public sealed class CosLexer : IDisposable
         }
     }
 
-    public void EatNewlines()
+    public void ReadEndOfLineMarker()
     {
         EnsureNotDisposed();
 
+        // PDF Spec - 7.3.8.1, Paragraph 3.
+        // The keyword stream that follows the stream dictionary shall be followed by an end-of-line marker
+        // consisting of either a CARRIAGE RETURN and a LINE FEED or just a LINE FEED, and not by a CARRIAGE
+        // RETURN alone.
+        // See also NOTE 2 in the same section.
         while (_reader.CanRead)
         {
-            var current = _reader.PeekChar();
-            switch (current)
+            var current = _reader.ReadChar();
+            if (current == '\n')
             {
-                case '\r':
-                case '\n':
-                    _reader.Discard();
-                    break;
-                default:
+                return;
+            }
+            else if (current == '\r')
+            {
+                current = _reader.ReadChar();
+                if (current == '\n')
+                {
                     return;
+                }
+                else
+                {
+                    throw new WispLexerException(this, $"Invalid end-of-line marker. Expected LF, instead got '{current}'");
+                }
+            }
+            else
+            {
+                throw new WispLexerException(this, "Expected an end-of-line marker consisting either of CRLF or a single LF.");
             }
         }
     }

--- a/src/Wisp/Parsing/CosParser.cs
+++ b/src/Wisp/Parsing/CosParser.cs
@@ -297,7 +297,7 @@ public sealed class CosParser : IDisposable
 
         // Read the stream data
         _lexer.Expect(CosTokenKind.BeginStream);
-        _lexer.EatNewlines();
+        _lexer.ReadEndOfLineMarker();
         var data = _lexer.ReadBytes(length.Value);
         _lexer.Expect(CosTokenKind.EndStream);
 

--- a/src/Wisp/Parsing/CosParser.cs
+++ b/src/Wisp/Parsing/CosParser.cs
@@ -297,7 +297,20 @@ public sealed class CosParser : IDisposable
 
         // Read the stream data
         _lexer.Expect(CosTokenKind.BeginStream);
-        _lexer.ReadEndOfLineMarker();
+
+        var current = _lexer.ReadByte();
+        if (current == '\r')
+        {
+            if (_lexer.ReadByte() != '\n')
+            {
+                throw new WispParserException(this, $"Invalid end-of-line marker. Expected LF, instead got '{current}'");
+            }
+        }
+        else if (current != '\n')
+        {
+            throw new WispParserException(this, "Expected an end-of-line marker consisting either of CRLF or a single LF.");
+        }
+
         var data = _lexer.ReadBytes(length.Value);
         _lexer.Expect(CosTokenKind.EndStream);
 


### PR DESCRIPTION
Hey, thanks for sharing this awesome project! 

I ran some PDFs from Wikileaks (PDF 1.7) and came across some errors when parsing the stream objects in `CosParser`. Here's a fix to conform with the spec.

A quote from PDF spec: 
> 7.3.8 Stream Objects
> ...
> The keyword stream that follows the stream dictionary shall be followed by an end-of-line marker consisting of either a CARRIAGE RETURN and a LINE FEED or just a LINE FEED, and not by a CARRIAGE RETURN alone.
> ..
> NOTE 2 Without the restriction against following the keyword stream by a CARRIAGE RETURN alone, it would be impossible to differentiate a stream that uses CARRIAGE RETURN as its end-of-line marker and has a LINE FEED as its first byte of data from one that uses a CARRIAGE RETURN–LINE FEED sequence to denote end-of-line.