### PR TITLE
Fixed CosWriter.cs Unicode write bug

### DIFF
--- a/src/Wisp/CosWriter.cs
+++ b/src/Wisp/CosWriter.cs
@@ -173,7 +173,7 @@ public sealed class CosWriter : IDisposable
             context.Writer.WriteBytes(obj.Encoding switch
             {
                 CosStringEncoding.Ascii => Encoding.ASCII.GetBytes(text),
-                CosStringEncoding.Unicode => [..(byte[])[0xFF, 0xFE], .. Encoding.BigEndianUnicode.GetBytes(text)],
+                CosStringEncoding.Unicode => [..(byte[])[0xFF, 0xFE], .. Encoding.Unicode.GetBytes(text)],
                 CosStringEncoding.BigEndianUnicode => [..(byte[])[0xFE, 0xFF], .. Encoding.BigEndianUnicode.GetBytes(text)],
                 _ => throw new WispException("Unknown string encoding"),
             });


### PR DESCRIPTION
When I was using your code as a reference (C# code "documents" are easier to parse than the PDF standard on some points). I came across the CosWriter, and while skimming the code I noticed you used the same Encoding for both `CosStringEncoding.Unicode` and `CosStringEncoding.BigEndianUnicode`.

So this PR is a small fix to use `Encoding.Unicode` when `CosStringEncoding.Unicode` is "selected".